### PR TITLE
Fixed CSS Styling on embeded  social tiles

### DIFF
--- a/src/containers/LinksSocial.tsx
+++ b/src/containers/LinksSocial.tsx
@@ -65,13 +65,17 @@ const SocialWrap = styled.section`
 
   & * {
     height: 480px !important;
+  }
+
+  & > * {
     padding: 0 1em;
+    width: 300px;
   }
 
   & .fb-page {
     border-radius: 8px !important;
-    left: -2em;
   }
+
   @media screen and (max-width: 1300px) {
     padding-top: 10px;
     & .fb-page {
@@ -136,7 +140,7 @@ export default function (): React.ReactElement {
               className="fb-page"
               data-href="https://www.facebook.com/NetsocUCC"
               data-tabs="timeline"
-              data-width="250"
+              data-width="300"
               data-height=""
               data-small-header="false"
               data-adapt-container-width="true"


### PR DESCRIPTION
- **Before**

![Before](https://i.gyazo.com/193251f7b12e97bae8fc34eee36d0c60.png)

- **After**

![After](https://i.gyazo.com/f859bbaf4b0df5b61bcddebea266df8b.png)

Implementation hasnt messed with the responsive views, works as expected