### PR TITLE
Fixed link styling bug to do with a:visted causing wrong text color Closes #24

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,11 +36,13 @@
         padding: 0;
         border: 0;
       }
+      a {
+        color: #fff;
+      }
       a,
       a:active,
       a:visited {
         text-decoration: none;
-        color: #fff;
       }
     </style>
   </head>


### PR DESCRIPTION
Closes #24