### PR TITLE
Minor OCD Addition

### DIFF
--- a/src/containers/News.tsx
+++ b/src/containers/News.tsx
@@ -183,6 +183,10 @@ export default function (props: NewsProps): React.ReactElement<NewsProps> {
                   day: '2-digit',
                 }).format(date);
                 let str = announce.content;
+                if (str.includes("<#")) {
+                  str = str.replace(/\<#\d+>/g, "<a href='http://discord.netsoc.co/'>Discord</a>")
+                }
+                str = str.charAt(0).toUpperCase() + str.slice(1)
                 let changed = true;
                 while (changed) {
                   [str, changed] = replacer(str);


### PR DESCRIPTION
 Added formatting in the news section to convert raw discord channel ID's to a link to the server

Before: https://i.gyazo.com/328cb1c940a5c1d4fd742674c06a339c.png

After: https://i.gyazo.com/436fd0a7313a0856714419ae0d7e0ef1.png